### PR TITLE
[prettierx] WIP TEST of tests/standard with alignObjectProperties: true - KNOWN ISSUE

### DIFF
--- a/tests/standard/jsfmt.spec.js
+++ b/tests/standard/jsfmt.spec.js
@@ -1,4 +1,5 @@
 run_spec(__dirname, ["babel", "flow", "typescript"], {
+  alignObjectProperties: true,
   endOfLine: "lf",
   yieldStarSpacing: true,
   generatorStarSpacing: true,


### PR DESCRIPTION
DEMONSTRATES A KNOWN ISSUE where `src/language-js/printer-estree.js` throws an exception:

```
    TypeError: Cannot read property 'raw' of undefined

      226 |       : n.raw
      227 |       ? n.raw.length
    > 228 |       : n.extra.raw
          |                 ^
      229 |       ? n.extra.raw.length
      230 |       : undefined;
      231 | 

      at getPropertyPadding (src/language-js/printer-estree.js:228:17)
      at FastPath.call (src/common/fast-path.js:69:18)
      at printPathNoParens (src/language-js/printer-estree.js:1507:38)
      at Object.genericPrint [as print] (src/language-js/printer-estree.js:96:30)
      at callPluginPrintFunction (src/main/ast-to-doc.js:126:18)
      at comments.printComments.p (src/main/ast-to-doc.js:63:14)
      at Object.printComments (src/main/comments.js:488:19)
      at printGenerically (src/main/ast-to-doc.js:61:22)
      at path.each.childPath (src/language-js/printer-estree.js:1403:22)
      at FastPath.each (src/common/fast-path.js:103:7)
```

FUTURE TODO: Once the known issue is resolved, should update `tests/standard` to cover behavior with and without the `alignObjectProperties: true` setting enabled.