### PR TITLE
Bump prettier to 1.19.1

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -1,34 +1,4 @@
-<!--
-
-NOTE: Don't forget to add a link to your GitHub profile and the PR in the end of the file.
-
-Format:
-
-#### Category: Title ([#PR] by [@user])
-
-Description
-
-```
-// Input
-Code Sample
-
-// Output (Prettier stable)
-Code Sample
-
-// Output (Prettier master)
-Code Sample
-```
-
-Details:
-
-  Description: optional if the `Title` is enough to explain everything.
-
-Examples:
-
-#### TypeScript: Correctly handle `//` in TSX ([#5728] by [@JamesHenry])
-
-Previously, putting `//` as a child of a JSX element in TypeScript led to an error
-because it was interpreted as a comment. Prettier master fixes this issue.
+#### Dependencies: Update prettier ([#PR] by [@user])
 
 <!-- prettier-ignore --\>
 ```js

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "jest-snapshot-serializer-raw": "1.1.0",
     "jest-watch-typeahead": "0.1.0",
     "mkdirp": "0.5.1",
-    "prettier": "1.17.1",
+    "prettier": "1.19.1",
     "prettylint": "1.0.0",
     "rimraf": "2.6.3",
     "rollup": "0.47.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5399,9 +5399,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^23.2.0:
   version "23.2.0"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Update `prettier` dependency to v1.19.1, which provides support for TypeScript 3.7. 🙏 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
