### PR TITLE
add test & fix for wrong space in typescript generic function expression

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4734,7 +4734,11 @@ function printFunctionDeclaration(path, print, options) {
         // [prettierx] spaceBeforeFunctionParen option support (...)
         options.spaceBeforeFunctionParen ||
         // [prettierx] parenSpace generatorStarSpacing option support (...)
-        (options.generatorStarSpacing && !n.id && (n.typeParameters ? n.typeParameters.type !== 'TSTypeParameterDeclaration' : true))
+        (options.generatorStarSpacing &&
+          !n.id &&
+          (n.typeParameters
+            ? n.typeParameters.type !== "TSTypeParameterDeclaration"
+            : true))
           ? " "
           : "",
         printFunctionParams(path, print, options),

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4734,7 +4734,7 @@ function printFunctionDeclaration(path, print, options) {
         // [prettierx] spaceBeforeFunctionParen option support (...)
         options.spaceBeforeFunctionParen ||
         // [prettierx] parenSpace generatorStarSpacing option support (...)
-        (options.generatorStarSpacing && !n.id)
+        (options.generatorStarSpacing && !n.id && (n.typeParameters ? n.typeParameters.type !== 'TSTypeParameterDeclaration' : true))
           ? " "
           : "",
         printFunctionParams(path, print, options),

--- a/tests/typescript_generic/function-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_generic/function-expression/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`function-expression.ts 1`] = `
+====================================options=====================================
+generatorStarSpacing: true
+parsers: ["typescript"]
+printWidth: 80
+spaceBeforeFunctionParen: false
+                                                                                | printWidth
+=====================================input======================================
+const foo = function<T>(bar: T) {
+  return bar
+}
+
+=====================================output=====================================
+const foo = function<T>(bar: T) {
+  return bar;
+};
+
+================================================================================
+`;

--- a/tests/typescript_generic/function-expression/function-expression.ts
+++ b/tests/typescript_generic/function-expression/function-expression.ts
@@ -1,0 +1,3 @@
+const foo = function<T>(bar: T) {
+  return bar
+}

--- a/tests/typescript_generic/function-expression/jsfmt.spec.js
+++ b/tests/typescript_generic/function-expression/jsfmt.spec.js
@@ -1,0 +1,4 @@
+run_spec(__dirname, ["typescript"], {
+  spaceBeforeFunctionParen: false,
+  generatorStarSpacing: true
+});


### PR DESCRIPTION
provides a test for #52, seems `generatorStarSpacing: true` affects output

closes #52 