### PR TITLE
prettierx: void vs self-closing tag format option

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "html-element-attributes": "2.2.1",
     "html-styles": "1.0.0",
     "html-tag-names": "1.1.5",
+    "html-void-elements": "1.0.5",
     "ignore": "4.0.6",
     "is-ci": "2.0.0",
     "jest-docblock": "25.3.0",

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -36,7 +36,8 @@ const {
   preferHardlineAsLeadingSpaces,
   shouldNotPrintClosingTag,
   shouldPreserveContent,
-  unescapeQuoteEntities
+  unescapeQuoteEntities,
+  isHtmlVoidElement,
 } = require("./utils");
 const { replaceEndOfLineWith } = require("../common/util");
 const preprocess = require("./preprocess");
@@ -613,7 +614,7 @@ function printOpeningTag(path, options, print) {
   return concat([
     printOpeningTagStart(node, options),
     !node.attrs || node.attrs.length === 0
-      ? node.isSelfClosing
+      ? node.isSelfClosing && !isHtmlVoidElement(node, options)
         ? /**
            *     <br />
            *        ^
@@ -671,8 +672,10 @@ function printOpeningTag(path, options, print) {
            */
           (node.isSelfClosing &&
             needsToBorrowLastChildClosingTagEndMarker(node.parent))
-            ? ""
-            : node.isSelfClosing
+            ? node.isSelfClosing && !isHtmlVoidElement(node, options)
+              ? " "
+              : ""
+            : node.isSelfClosing && !isHtmlVoidElement(node, options)
             ? forceNotToBreakAttrContent
               ? " "
               : line
@@ -900,7 +903,7 @@ function printClosingTagEndMarker(node, options) {
       return "}}";
     case "element":
       if (node.isSelfClosing) {
-        return "/>";
+        return isHtmlVoidElement(node, options) ? ">" : "/>";
       }
     // fall through
     default:

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const htmlVoidElements = require("html-void-elements");
 const {
   CSS_DISPLAY_TAGS,
   CSS_DISPLAY_DEFAULT,
@@ -601,6 +602,11 @@ function unescapeQuoteEntities(text) {
   return text.replace(/&apos;/g, "'").replace(/&quot;/g, '"');
 }
 
+const htmlVoidElementsSet = new Set(htmlVoidElements);
+function isHtmlVoidElement(node, options) {
+  return options.parser === "html" && htmlVoidElementsSet.has(node.fullName);
+}
+
 module.exports = {
   HTML_ELEMENT_ATTRIBUTES,
   HTML_TAGS,
@@ -632,5 +638,6 @@ module.exports = {
   preferHardlineAsTrailingSpaces,
   shouldNotPrintClosingTag,
   shouldPreserveContent,
-  unescapeQuoteEntities
+  unescapeQuoteEntities,
+  isHtmlVoidElement,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3873,6 +3873,11 @@ html-tag-names@1.1.5:
   resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.5.tgz#f537420c16769511283f8ae1681785fbc89ee0a9"
   integrity sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==
 
+html-void-elements@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
+  integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
+
 http-proxy-agent@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"


### PR DESCRIPTION
as discussed in <https://github.com/prettier/prettier/issues/5246>

__(updated)__

- detect void HTML element vs self-closing XML tag; omit `/` in case of void HTML element (cherry-picked from <https://github.com/prettier/prettier/pull/8628>)


TODO:

- [ ] make this optional
- [ ] test with & without the option enabled in `tests/html_tags`; special attention should be given to the following issues:
  - #282 (same as <https://github.com/prettier/prettier/issues/6028>)
  - <https://github.com/prettier/prettier/issues/7393>

Note that the cherry-picked change will add an extra space in case of a self-closing XML tag.