### PR TITLE
prettierx cleanup: back out a parenLine change

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4499,7 +4499,7 @@ function printArgumentsList(path, options, print) {
           concat([
             ifBreak(
               // [prettierx] parenSpace option support (...)
-              indent(concat(["(", parenLine, concat(printedExpanded)])),
+              indent(concat(["(", softline, concat(printedExpanded)])),
               concat(["(", parenSpace, concat(printedExpanded)])
             ),
             // [prettierx] parenSpace option support (...)


### PR DESCRIPTION
that does not seem to be needed