### PR TITLE
Update find-parent-dir dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "escape-string-regexp": "4.0.0",
     "esutils": "2.0.3",
     "fast-glob": "3.2.5",
-    "find-parent-dir": "0.3.0",
+    "find-parent-dir": "^0.3.1",
     "find-project-root": "1.1.1",
     "get-stream": "6.0.1",
     "globby": "11.0.3",


### PR DESCRIPTION
Silences Node deprecation warning [DEP0128](https://nodejs.org/api/deprecations.html#DEP0128).
Resolves #563