### PR TITLE
prettierx docs: update browser status for prettierX

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -5,7 +5,7 @@ title: Browser
 
 ## browser status for prettierX
 
-This documentation does **not** apply for prettierX. The recommended solution is to use a bundler such as Rollup or Webpack. This is tracked with some more information in this issue: [`brodybits/prettierx#95`](https://github.com/brodybits/prettierx/issues/95)
+This documentation does **not** apply for prettierX. The recommended solution is to use a bundler such as Rollup or Webpack. This is tracked with some more information in: [`brodybits/prettierx#95`](https://github.com/brodybits/prettierx/issues/95)
 
 ---
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -9,7 +9,6 @@ This documentation does **not** apply for prettierX. The recommended solution is
 
 ---
 
-
 Run Prettier in the browser with the `standalone.js` UMD bundle shipped in the NPM package (starting in version 1.13). The UMD bundle only formats the code and has no support for config files, ignore files, CLI usage, or automatic loading of plugins.
 
 ### `prettier.format(code, options)`

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -3,6 +3,13 @@ id: browser
 title: Browser
 ---
 
+## browser status for prettierX
+
+This documentation does **not** apply for prettierX. The recommended solution is to use a bundler such as Rollup or Webpack. This is tracked with some more information in this issue: [`brodybits/prettierx#95`](https://github.com/brodybits/prettierx/issues/95)
+
+---
+
+
 Run Prettier in the browser with the `standalone.js` UMD bundle shipped in the NPM package (starting in version 1.13). The UMD bundle only formats the code and has no support for config files, ignore files, CLI usage, or automatic loading of plugins.
 
 ### `prettier.format(code, options)`
@@ -29,8 +36,8 @@ See [Usage](#usage) below for examples.
 ### ES Modules
 
 ```js
-import prettier from "prettierx/standalone";
-import parserGraphql from "prettierx/parser-graphql";
+import prettier from "prettier/standalone";
+import parserGraphql from "prettier/parser-graphql";
 
 prettier.format("query { }", {
   parser: "graphql",
@@ -52,8 +59,8 @@ define([
 ### CommonJS
 
 ```js
-const prettier = require("prettierx/standalone");
-const plugins = [require("prettierx/parser-graphql")];
+const prettier = require("prettier/standalone");
+const plugins = [require("prettier/parser-graphql")];
 prettier.format("query { }", { parser: "graphql", plugins });
 ```
 


### PR DESCRIPTION
as discussed in this issue:

- https://github.com/brodybits/prettierx/issues/95

and revert updates to `docs/browser.md` from this commit:

- https://github.com/brodybits/prettierx/commit/a48be8e68487d3f9dd1b7559a46cd8c964d113f4

---

P.S. I discovered this while merging updates from Prettier 2.3.1 in PR #616.