### PR TITLE
added line breaks before closing brackets when mappingValue contains …

### DIFF
--- a/src/language-yaml/print/flow-mapping-sequence.js
+++ b/src/language-yaml/print/flow-mapping-sequence.js
@@ -42,7 +42,7 @@ function printFlowMapping(path, print, options) {
 
 function hasCommentOnAnyChildren(node) {
   let hasComment = false;
-  node.children.each(child => {
+  for (const child of node.children) {
     if (isNode(child, ["flowMappingItem"])) {
       const { value } = child;
       const isEmptyMappingValue = isEmptyNode(value);
@@ -50,7 +50,7 @@ function hasCommentOnAnyChildren(node) {
         hasComment = true;
       }
     }
-  });
+  }
   return hasComment;
 }
 

--- a/src/language-yaml/utils.js
+++ b/src/language-yaml/utils.js
@@ -371,4 +371,5 @@ module.exports = {
   hasIndicatorComment,
   hasTrailingComment,
   hasEndComments,
+  hasComments,
 };


### PR DESCRIPTION
For addressing the issue https://github.com/redhat-developer/vscode-yaml/issues/449, checked if the mapping value contains any comments, if so added the line breaks before the "}"