### PR TITLE
Add jsxSpaceBeforeSelfClosingTag option

### DIFF
--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -248,4 +248,11 @@ module.exports = {
       },
     ],
   },
+  jsxSpaceBeforeSelfClosingTag: {
+    since: "0.20.0",
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: true,
+    description: "Put a space before /> in self-closing tags.",
+  },
 };

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -554,7 +554,7 @@ function printJsxOpeningElement(path, options, print) {
 
   // Don't break self-closing elements with no attributes and no comments
   if (node.selfClosing && node.attributes.length === 0 && !nameHasComments) {
-    return ["<", print("name"), print("typeParameters"), " />"];
+    return ["<", print("name"), print("typeParameters"), options.jsxSpaceBeforeSelfClosingTag ? " />" : "/>"];
   }
 
   // don't break up opening elements with a single long text attribute
@@ -582,7 +582,7 @@ function printJsxOpeningElement(path, options, print) {
       print("typeParameters"),
       " ",
       ...path.map(print, "attributes"),
-      node.selfClosing ? " />" : ">",
+      node.selfClosing ? (options.jsxSpaceBeforeSelfClosingTag ? " />" : "/>") : ">",
     ]);
   }
 


### PR DESCRIPTION
Make it possible to customize whether to put a space before the `/>` part in self-closing tags in JSX.  On by default, to keep compatibility with the current defaults.

Before:

```js
export default function Component() {
    return (
        <div>
            <img src="some-image" />
        </div>
    );
}

```

After (with `--no-jsx-space-before-self-closing-tag` flag):

```js
export default function Component() {
    return (
        <div>
            <img src="some-image"/>
        </div>
    );
}
```